### PR TITLE
Add Ostinato packet crafter and traffic generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Traffic Analysis/Inspection<a name="analysis"></a>
 
 * [Ntopng](https://www.ntop.org/products/traffic-analysis/ntop/): Ntopng is the next generation version of the original ntop, a network traffic probe that shows the network usage, similar to what the popular top Unix command does. ntop is based on libpcap and it has been written in a portable way in order to virtually run on every Unix platform, MacOSX and on Win32 as well.
 
+* [Ostinato](https://ostinato.org/): Ostinato is a versatile packet crafter, pcap editor/player and traffic generator with an intuitive GUI. Add-ons include high-speed 10/25/40G traffic generation and scripting/ automation Python APIs. Works on all platforms - Windows, MacOS, Linux and the labbing platforms - CML, EVE-NG and GNS3.
+
 * [PacketQ](https://github.com/dotse/PacketQ): A tool that provides a basic SQL-frontend to PCAP-files. Outputs JSON, CSV and XML and includes a build-in webserver with JSON-api and a nice looking AJAX GUI.
 
 * [Pcap2har](https://github.com/andrewf/pcap2har): A program to convert .pcap network capture files to HTTP Archive files using library dpkt.


### PR DESCRIPTION
I've added this to the _Traffic Analysis/Inspection_ category currently.

But that category seems too generic and bulky for the tools it lists - if you are open to it, I can split the tools in that category into multiple categories.